### PR TITLE
略微修改ffmpeg的调用参数

### DIFF
--- a/DDTV_Core/SystemAssembly/ConfigModule/CoreConfigClass.cs
+++ b/DDTV_Core/SystemAssembly/ConfigModule/CoreConfigClass.cs
@@ -105,8 +105,8 @@ namespace DDTV_Core.SystemAssembly.ConfigModule
             /// </summary>
             DownloadFolderName,
             /// <summary>
-            /// 转码默认参数 (应该是带{After}{Before}的ffmpeg参数字符串，如:-i {Before} -vcodec copy -acodec copy {After})
-            /// 组：Core      默认值：-i {Before} -vcodec copy -acodec copy {After}
+            /// 转码默认参数 (应该是带{After}{Before}的ffmpeg参数字符串，如:-y -hide_banner -loglevel warning -i {Before} -c copy {After})
+            /// 组：Core      默认值：-y -hide_banner -loglevel warning -i {Before} -c copy {After}
             /// </summary>
             TranscodParmetrs,
             /// <summary>

--- a/DDTV_Core/Tool/TranscodModule/Transcod.cs
+++ b/DDTV_Core/Tool/TranscodModule/Transcod.cs
@@ -17,7 +17,7 @@ namespace DDTV_Core.Tool.TranscodModule
     public class Transcod
     {
         public static bool IsAutoTranscod = bool.Parse(CoreConfig.GetValue(CoreConfigClass.Key.IsAutoTranscod, "True", CoreConfigClass.Group.Core));
-        public static string TranscodParmetrs = CoreConfig.GetValue(CoreConfigClass.Key.TranscodParmetrs, "-i {Before} -vcodec copy -acodec copy {After}", CoreConfigClass.Group.Core);
+        public static string TranscodParmetrs = CoreConfig.GetValue(CoreConfigClass.Key.TranscodParmetrs, "-y -hide_banner -loglevel warning -i {Before} -c copy {After}", CoreConfigClass.Group.Core);
         public static bool TranscodingCompleteAutoDeleteFiles = bool.Parse(CoreConfig.GetValue(CoreConfigClass.Key.TranscodingCompleteAutoDeleteFiles, "False", CoreConfigClass.Group.Core));
         /// <summary>
         /// 调用ffmpeg进行转码

--- a/DDTV_GUI/DDTV_Window/NewClipWindow.xaml.cs
+++ b/DDTV_GUI/DDTV_Window/NewClipWindow.xaml.cs
@@ -340,7 +340,7 @@ namespace DDTV_GUI.DDTV_Window
                     .Replace(OriginalFilePath.Split('/')[OriginalFilePath.Split('/').Length - 1], "")+OriginalFilePath.Split('/')[OriginalFilePath.Split('/').Length - 1])
                     .Replace(".mp4", $"_激光切片_{new Random().Next(1000, 9999)}.mp4")
                     .Replace(".flv", $"_激光切片_{new Random().Next(1000, 9999)}.mp4"),
-                }, false, false, "-i {Before} -vcodec copy -acodec copy -ss " + Start.ToString("HH:mm:ss") + " -to " + End.ToString("HH:mm:ss") + " {After} ");
+                }, false, false, "-y -hide_banner -loglevel warning -i {Before} -c copy -ss " + Start.ToString("HH:mm:ss") + " -to " + End.ToString("HH:mm:ss") + " {After} ");
                  SetLoading(0);
                 Growl.SuccessGlobal($"切片完成:{tm.AfterFilePath}");
             });

--- a/Doc/docs/API/README.md
+++ b/Doc/docs/API/README.md
@@ -272,8 +272,8 @@ DDTV_WEB_Server自带swagger方便进行调试，请使用`http(s)://[IP地址]:
             /// </summary>
             DownloadFileName,
             /// <summary>
-            /// 转码默认参数 (应该是带{After}{Before}的ffmpeg参数字符串，如:-i {Before} -vcodec copy -acodec copy {After})
-            /// 组：Core      默认值：-i {Before} -vcodec copy -acodec copy {After}
+            /// 转码默认参数 (应该是带{After}{Before}的ffmpeg参数字符串，如:-y -hide_banner -loglevel warning -i {Before} -c copy {After})
+            /// 组：Core      默认值：-y -hide_banner -loglevel warning -i {Before} -c copy {After}
             /// </summary>
             TranscodParmetrs,
             /// <summary>

--- a/Doc/docs/config/DDTV_Config.md
+++ b/Doc/docs/config/DDTV_Config.md
@@ -149,8 +149,8 @@ ShowGuardSwitch=False
             /// </summary>
             DownloadFolderName,
             /// <summary>
-            /// 转码默认参数 (应该是带{After}{Before}的ffmpeg参数字符串，如:-i {Before} -vcodec copy -acodec copy {After})
-            /// 组：Core      默认值：-i {Before} -vcodec copy -acodec copy {After}
+            /// 转码默认参数 (应该是带{After}{Before}的ffmpeg参数字符串，如:-y -hide_banner -loglevel warning -i {Before} -c copy {After})
+            /// 组：Core      默认值：-y -hide_banner -loglevel warning -i {Before} -c copy {After}
             /// </summary>
             TranscodParmetrs,
             /// <summary>


### PR DESCRIPTION
`-i {Before} -vcodec copy -acodec copy {After}` 改为 `-y -hide_banner -loglevel warning -i {Before} -c copy {After}`

预防可能的交互式确认（尤其是无人值守的情况）。隐藏了冗长的、每次调用ffmpeg都要展示的版本和编译信息。