### PR TITLE
优化Core/Tools/Fmp4Repair.cs流程，对应修复ToolsPage.xaml.cs自动修复设置

### DIFF
--- a/Core/Tools/Fmp4Repair.cs
+++ b/Core/Tools/Fmp4Repair.cs
@@ -12,13 +12,38 @@ namespace Core.Tools
     /// </summary>
     public static class Fmp4Repair
     {
+        private const uint Ftyp = 0x66747970;
+        private const uint Moov = 0x6D6F6F76;
+        private const uint Moof = 0x6D6F6F66;
+        private const uint Mdat = 0x6D646174;
+
         /// <summary>
-        /// 检测 fMP4 文件是否存在结构断裂
+        /// 扫描结果类，包含 Box 索引和损坏信息
         /// </summary>
-        /// <param name="filePath">待检测的文件路径</param>
-        /// <returns>true 表示存在断裂，false 表示结构完整</returns>
-        public static bool DetectCorruption(string filePath)
+        public sealed class ScanResult
         {
+            public bool IsCorrupted { get; set; }
+            public List<(long offset, uint type, long size)> Boxes { get; set; } = new List<(long offset, uint type, long size)>();
+            public int RecoveryCount { get; set; }
+        }
+
+        /// <summary>
+        /// 扫描 fMP4 文件结构
+        /// </summary>
+        /// <param name="filePath">文件路径</param>
+        /// <returns>扫描结果</returns>
+        public static ScanResult Scan(string filePath)
+        {
+            return ScanStructure(filePath);
+        }
+
+        private static ScanResult ScanStructure(string filePath)
+        {
+            var result = new ScanResult();
+            byte[] header = new byte[8];
+            byte[] sizeBytes = new byte[4];
+            byte[] typeBytes = new byte[4];
+
             try
             {
                 using (var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read))
@@ -26,15 +51,15 @@ namespace Core.Tools
                     long fileLen = fs.Length;
                     long offset = 0;
 
+                    byte[] extSize = new byte[8];
                     while (offset < fileLen - 8)
                     {
                         fs.Seek(offset, SeekOrigin.Begin);
-                        byte[] header = new byte[8];
                         int read = fs.Read(header, 0, 8);
                         if (read < 8) break;
 
                         uint size = (uint)((header[0] << 24) | (header[1] << 16) | (header[2] << 8) | header[3]);
-                        string type = Encoding.ASCII.GetString(header, 4, 4);
+                        uint type = (uint)((header[4] << 24) | (header[5] << 16) | (header[6] << 8) | header[7]);
 
                         if (size == 0)
                         {
@@ -45,7 +70,7 @@ namespace Core.Tools
                             if (offset + 16 <= fileLen)
                             {
                                 fs.Seek(offset + 8, SeekOrigin.Begin);
-                                byte[] extSize = new byte[8];
+                                
                                 fs.Read(extSize, 0, 8);
                                 size = (uint)((extSize[0] << 24) | (extSize[1] << 16) | (extSize[2] << 8) | extSize[3]);
                             }
@@ -54,131 +79,44 @@ namespace Core.Tools
 
                         if (size < 8 || size > fileLen - offset)
                         {
+                            result.IsCorrupted = true;
                             // 尝试在后续 5MB 范围内恢复
+                            long searchStart = offset + 1;
                             long searchEnd = Math.Min(offset + 5000000, fileLen - 8);
-                            for (long searchPos = offset + 1; searchPos < searchEnd; searchPos++)
-                            {
-                                fs.Seek(searchPos, SeekOrigin.Begin);
-                                byte[] sig = new byte[4];
-                                fs.Read(sig, 0, 4);
-                                if (sig[0] == 'm' && sig[1] == 'o' && sig[2] == 'o' && sig[3] == 'f' ||
-                                    sig[0] == 'm' && sig[1] == 'd' && sig[2] == 'a' && sig[3] == 't')
-                                {
-                                    long candidateOffset = searchPos - 4;
-                                    if (candidateOffset >= offset && candidateOffset + 8 <= fileLen)
-                                    {
-                                        fs.Seek(candidateOffset, SeekOrigin.Begin);
-                                        byte[] sizeBytes = new byte[4];
-                                        fs.Read(sizeBytes, 0, 4);
-                                        uint candidateSize = (uint)((sizeBytes[0] << 24) | (sizeBytes[1] << 16) | (sizeBytes[2] << 8) | sizeBytes[3]);
-                                        if (candidateSize >= 8 && candidateSize <= fileLen - candidateOffset)
-                                        {
-                                            fs.Seek(candidateOffset + 4, SeekOrigin.Begin);
-                                            byte[] typeBytes = new byte[4];
-                                            fs.Read(typeBytes, 0, 4);
-                                            if (typeBytes[0] == sig[0] && typeBytes[1] == sig[1] && typeBytes[2] == sig[2] && typeBytes[3] == sig[3])
-                                            {
-                                                Log.Info(nameof(DetectCorruption), $"检测到 fMP4 结构断裂: 文件={filePath}, 断裂偏移={offset}, 恢复偏移={candidateOffset}, 垃圾数据大小={candidateOffset - offset}");
-                                                return true;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            // 无法恢复，结构结束
-                            break;
-                        }
+                            int searchLen = (int)(searchEnd - searchStart);
 
-                        offset += (long)size;
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(nameof(DetectCorruption), $"检测 fMP4 文件时发生错误: {filePath}", ex);
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// 修复 fMP4 文件结构断裂，提取所有有效的 moof+mdat 对重新封装
-        /// </summary>
-        /// <param name="inputPath">输入的损坏文件路径</param>
-        /// <param name="outputPath">输出的修复后文件路径</param>
-        /// <returns>true 表示修复成功，false 表示修复失败</returns>
-        public static bool RepairStructure(string inputPath, string outputPath)
-        {
-            try
-            {
-                using (var fs = new FileStream(inputPath, FileMode.Open, FileAccess.Read))
-                using (var outFs = new FileStream(outputPath, FileMode.Create, FileAccess.Write))
-                {
-                    long fileLen = fs.Length;
-                    long offset = 0;
-                    var boxes = new List<(long offset, string type, long size)>();
-                    int recoveryCount = 0;
-
-                    // 第一步：解析所有 top-level box
-                    while (offset < fileLen - 8)
-                    {
-                        fs.Seek(offset, SeekOrigin.Begin);
-                        byte[] header = new byte[8];
-                        int read = fs.Read(header, 0, 8);
-                        if (read < 8) break;
-
-                        uint size = (uint)((header[0] << 24) | (header[1] << 16) | (header[2] << 8) | header[3]);
-                        string type = Encoding.ASCII.GetString(header, 4, 4);
-
-                        if (size == 0)
-                        {
-                            size = (uint)(fileLen - offset);
-                        }
-                        else if (size == 1)
-                        {
-                            if (offset + 16 <= fileLen)
-                            {
-                                fs.Seek(offset + 8, SeekOrigin.Begin);
-                                byte[] extSize = new byte[8];
-                                fs.Read(extSize, 0, 8);
-                                size = (uint)((extSize[0] << 24) | (extSize[1] << 16) | (extSize[2] << 8) | extSize[3]);
-                            }
-                            else break;
-                        }
-
-                        if (size < 8 || size > fileLen - offset)
-                        {
-                            // 尝试恢复
                             bool found = false;
-                            long searchEnd = Math.Min(offset + 5000000, fileLen - 8);
-                            for (long searchPos = offset + 1; searchPos < searchEnd; searchPos++)
+                            if (searchLen > 0)
                             {
-                                fs.Seek(searchPos, SeekOrigin.Begin);
-                                byte[] sig = new byte[4];
-                                fs.Read(sig, 0, 4);
-                                if ((sig[0] == 'm' && sig[1] == 'o' && sig[2] == 'o' && sig[3] == 'f') ||
-                                    (sig[0] == 'm' && sig[1] == 'd' && sig[2] == 'a' && sig[3] == 't'))
+                                byte[] buffer = new byte[searchLen + 4];
+                                fs.Seek(searchStart, SeekOrigin.Begin);
+                                int bytesRead = fs.Read(buffer, 0, buffer.Length);
+
+                                for (int i = 0; i < bytesRead - 4; i++)
                                 {
-                                    long candidateOffset = searchPos - 4;
-                                    if (candidateOffset >= offset && candidateOffset + 8 <= fileLen)
+                                    uint currentType = (uint)((buffer[i] << 24) | (buffer[i + 1] << 16) | (buffer[i + 2] << 8) | buffer[i + 3]);
+                                    if (currentType == Moof || currentType == Mdat)
                                     {
-                                        fs.Seek(candidateOffset, SeekOrigin.Begin);
-                                        byte[] sizeBytes = new byte[4];
-                                        fs.Read(sizeBytes, 0, 4);
-                                        uint candidateSize = (uint)((sizeBytes[0] << 24) | (sizeBytes[1] << 16) | (sizeBytes[2] << 8) | sizeBytes[3]);
-                                        if (candidateSize >= 8 && candidateSize <= fileLen - candidateOffset)
+                                        long candidateOffset = searchStart + i - 4;
+                                        if (candidateOffset >= offset && candidateOffset + 8 <= fileLen)
                                         {
-                                            fs.Seek(candidateOffset + 4, SeekOrigin.Begin);
-                                            byte[] typeBytes = new byte[4];
-                                            fs.Read(typeBytes, 0, 4);
-                                            if (typeBytes[0] == sig[0] && typeBytes[1] == sig[1] && typeBytes[2] == sig[2] && typeBytes[3] == sig[3])
+                                            fs.Seek(candidateOffset, SeekOrigin.Begin);
+                                            fs.Read(sizeBytes, 0, 4);
+                                            uint candidateSize = (uint)((sizeBytes[0] << 24) | (sizeBytes[1] << 16) | (sizeBytes[2] << 8) | sizeBytes[3]);
+                                            if (candidateSize >= 8 && candidateSize <= fileLen - candidateOffset)
                                             {
-                                                recoveryCount++;
-                                                offset = candidateOffset;
-                                                size = candidateSize;
-                                                type = Encoding.ASCII.GetString(sig, 0, 4);
-                                                found = true;
-                                                break;
+                                                fs.Seek(candidateOffset + 4, SeekOrigin.Begin);
+                                                fs.Read(typeBytes, 0, 4);
+                                                uint candidateType = (uint)((typeBytes[0] << 24) | (typeBytes[1] << 16) | (typeBytes[2] << 8) | typeBytes[3]);
+                                                if (candidateType == currentType)
+                                                {
+                                                    result.RecoveryCount++;
+                                                    offset = candidateOffset;
+                                                    size = candidateSize;
+                                                    type = currentType;
+                                                    found = true;
+                                                    break;
+                                                }
                                             }
                                         }
                                     }
@@ -187,23 +125,44 @@ namespace Core.Tools
                             if (!found) break;
                         }
 
-                        boxes.Add((offset, type, (long)size));
+                        result.Boxes.Add((offset, type, (long)size));
                         offset += (long)size;
                     }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(nameof(ScanStructure), $"扫描 fMP4 文件时发生错误: {filePath}", ex);
+            }
 
-                    // 第二步：提取 init segment (ftyp + moov)
-                    byte[] initData = new byte[0];
+            return result;
+        }
+
+
+        /// <summary>
+        /// 修复 fMP4 文件结构断裂，提取所有有效的 moof+mdat 对重新封装
+        /// </summary>
+        /// <param name="inputPath">输入的损坏文件路径</param>
+        /// <param name="outputPath">输出的修复后文件路径</param>
+        /// <param name="preScannedResult">可选的前置扫描结果，如果提供则跳过扫描阶段</param>
+        /// <returns>true 表示修复成功，false 表示修复失败</returns>
+        public static bool RepairStructure(string inputPath, string outputPath, ScanResult preScannedResult = null)
+        {
+            try
+            {
+                var scanResult = preScannedResult ?? ScanStructure(inputPath);
+                var boxes = scanResult.Boxes;
+                byte[] copyBuffer = new byte[64 * 1024]; // 64KB 流式拷贝缓冲区
+
+                using (var fs = new FileStream(inputPath, FileMode.Open, FileAccess.Read))
+                using (var outFs = new FileStream(outputPath, FileMode.Create, FileAccess.Write))
+                {
+                    // 提取 init segment (ftyp + moov)
                     for (int i = 0; i < boxes.Count; i++)
                     {
-                        if (boxes[i].type == "ftyp" || boxes[i].type == "moov")
+                        if (boxes[i].type == Ftyp || boxes[i].type == Moov)
                         {
-                            byte[] boxData = new byte[boxes[i].size];
-                            fs.Seek(boxes[i].offset, SeekOrigin.Begin);
-                            fs.Read(boxData, 0, boxData.Length);
-                            byte[] newInit = new byte[initData.Length + boxData.Length];
-                            Buffer.BlockCopy(initData, 0, newInit, 0, initData.Length);
-                            Buffer.BlockCopy(boxData, 0, newInit, initData.Length, boxData.Length);
-                            initData = newInit;
+                            CopyRange(fs, outFs, boxes[i].offset, boxes[i].size, copyBuffer);
                         }
                         else
                         {
@@ -211,38 +170,21 @@ namespace Core.Tools
                         }
                     }
 
-                    if (initData.Length == 0)
-                    {
-                        Log.Warn(nameof(RepairStructure), $"未找到 ftyp/moov init segment: {inputPath}");
-                        return false;
-                    }
-
-                    outFs.Write(initData, 0, initData.Length);
-
-                    // 第三步：提取所有 moof+mdat 对
+                    // 提取所有 moof+mdat 对
                     int pairCount = 0;
                     for (int i = 0; i < boxes.Count - 1; i++)
                     {
-                        if (boxes[i].type == "moof" && boxes[i + 1].type == "mdat")
+                        if (boxes[i].type == Moof && boxes[i + 1].type == Mdat)
                         {
-                            // 写入 moof
-                            byte[] moofData = new byte[boxes[i].size];
-                            fs.Seek(boxes[i].offset, SeekOrigin.Begin);
-                            fs.Read(moofData, 0, moofData.Length);
-                            outFs.Write(moofData, 0, moofData.Length);
-
-                            // 写入 mdat
-                            byte[] mdatData = new byte[boxes[i + 1].size];
-                            fs.Seek(boxes[i + 1].offset, SeekOrigin.Begin);
-                            fs.Read(mdatData, 0, mdatData.Length);
-                            outFs.Write(mdatData, 0, mdatData.Length);
+                            CopyRange(fs, outFs, boxes[i].offset, boxes[i].size, copyBuffer);
+                            CopyRange(fs, outFs, boxes[i + 1].offset, boxes[i + 1].size, copyBuffer);
 
                             pairCount++;
-                            i++; // 跳过 mdat，因为已经处理了
+                            i++; // 跳过 mdat
                         }
                     }
 
-                    Log.Info(nameof(RepairStructure), $"fMP4 结构修复完成: 输入={inputPath}, 输出={outputPath}, 跳过断裂点={recoveryCount}, 有效片段对={pairCount}");
+                    Log.Info(nameof(RepairStructure), $"fMP4 结构修复完成: 输入={inputPath}, 输出={outputPath}, 跳过断裂点={scanResult.RecoveryCount}, 有效片段对={pairCount}");
                     return true;
                 }
             }
@@ -250,6 +192,23 @@ namespace Core.Tools
             {
                 Log.Error(nameof(RepairStructure), $"修复 fMP4 文件时发生错误: {inputPath}", ex);
                 return false;
+            }
+        }
+
+        /// <summary>
+        /// 拷贝指定范围的文件内容
+        /// </summary>
+        private static void CopyRange(FileStream src, FileStream dst, long offset, long size, byte[] buffer)
+        {
+            src.Seek(offset, SeekOrigin.Begin);
+            long remaining = size;
+            while (remaining > 0)
+            {
+                int toRead = (int)Math.Min(remaining, buffer.Length);
+                int read = src.Read(buffer, 0, toRead);
+                if (read <= 0) break;
+                dst.Write(buffer, 0, read);
+                remaining -= read;
             }
         }
     }

--- a/Desktop/Views/Pages/ToolsPage.xaml.cs
+++ b/Desktop/Views/Pages/ToolsPage.xaml.cs
@@ -53,13 +53,14 @@ public partial class ToolsPage
                     string after = result.Replace(".mp4", "_fix.mp4").Replace(".flv", "_fix.mp4");
 
                     // 检测是否是 fMP4 文件且存在结构断裂
-                    if (Core.Tools.Fmp4Repair.DetectCorruption(before))
+                    var scanResult = Core.Tools.Fmp4Repair.Scan(before);
+                    if (scanResult.IsCorrupted)
                     {
                         toolsPageModels.FixMessage = "检测到文件结构断裂，正在预处理...";
                         toolsPageModels.OnPropertyChanged("FixMessage");
 
                         tempRepairedPath = before + ".struct_repaired.mp4";
-                        bool repairSuccess = Core.Tools.Fmp4Repair.RepairStructure(before, tempRepairedPath);
+                        bool repairSuccess = Core.Tools.Fmp4Repair.RepairStructure(before, tempRepairedPath, scanResult);
                         if (repairSuccess)
                         {
                             before = tempRepairedPath;
@@ -72,34 +73,26 @@ public partial class ToolsPage
 
                     await transcode.TranscodeAsync(before, after);
 
-                    // 清理临时文件
-                    if (!string.IsNullOrEmpty(tempRepairedPath) && System.IO.File.Exists(tempRepairedPath))
-                    {
-                        try
-                        {
-                            System.IO.File.Delete(tempRepairedPath);
-                        }
-                        catch { }
-                    }
-
                     toolsPageModels.FixMessage = "文件修复完成";
                     toolsPageModels.OnPropertyChanged("FixMessage");
                 }
                 catch (Exception ex)
                 {
-                    // 清理临时文件
-                    if (!string.IsNullOrEmpty(tempRepairedPath) && System.IO.File.Exists(tempRepairedPath))
-                    {
-                        try
-                        {
-                            System.IO.File.Delete(tempRepairedPath);
-                        }
-                        catch { }
-                    }
-
                     toolsPageModels.FixMessage = "修复文件发生错误，详情查看日志";
                     toolsPageModels.OnPropertyChanged("FixMessage");
                     Log.Error(nameof(ManualFix_Button_Click), $"手动Fix时出现意外错误，文件:{result}");
+                }
+                finally
+                {
+                    // 清理临时文件
+                    if (!string.IsNullOrEmpty(tempRepairedPath) && File.Exists(tempRepairedPath))
+                    {
+                        try
+                        {
+                            File.Delete(tempRepairedPath);
+                        }
+                        catch { }
+                    }
                 }
             });
         }


### PR DESCRIPTION
# 描述

- 新增 `ScanResult` 类，统一保存扫描结果（Box 索引、损坏状态、恢复次数）。
- 新增 `Scan()` 接口，支持扫描结果复用。
- `RepairStructure()` 新增可选参数 `preScannedResult`，scan后可直接复用，避免重复扫描
- Box 类型由字符串改为 `uint` 常量，提高比较效率
- 扫描阶段采用一次性读取 5MB Buffer 搜索 `moof`/`mdat`，降低磁盘读次数提高文件效率
- 修复阶段新增可复用的`CopyRange()`，定义了流式复制，避免一次分配大内存
# 怎么测试的？

俺寻思跑起来了，测试后面再说

# 核查清单:

_请剔除无关项._

- [x] 我的代码符合项目的样式规范。
- [x] 我对我的代码进行了自我检查。
- [x] 我已对代码进行注释，特别是晦涩难懂的部分。
- [x] 我写的代码没蹦出新的警告。
